### PR TITLE
feat: DeepSeek 图片请求回退到 mimo-v2.5-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,10 @@ Authorization: Bearer <api-key>
 ## 推理强度（reasoning_effort）
 
 目前 `reasoning_effort` 仅对 DeepSeek 模型生效：DeepSeek 只接受 `high` / `max`，两者原样透传，其余值（包括未指定）会被强制为 `high`；其他模型不处理该参数，保持默认值。
+
+## 图片请求
+
+DeepSeek 仅支持文本输入。当**最近一条 `user` 消息**包含图片（`type` 为 `image_url` 或 `image` 的 content part）时，代理会把该请求路由到带图模型 `mimo-v2.5-free` 处理，并在响应中把 `model` 字段改写为您请求的 DeepSeek 模型，对客户端透明。
+
+- 路由只由**最近一条 user 消息**决定：历史中残留的图片不会再次触发回退。
+- 因此「发图提问 → 拿到结果后纯文字追问」的下一轮会**自动回到 DeepSeek**，不会一直走 `mimo-v2.5-free`。

--- a/api/index.js
+++ b/api/index.js
@@ -4,6 +4,7 @@ const ZEN_BASE_URL = "https://opencode.ai";
 const ZEN_URL = `${ZEN_BASE_URL}/zen/v1/chat/completions`;
 const ZEN_MODELS_URL = `${ZEN_BASE_URL}/zen/v1/models`;
 const FETCH_TIMEOUT_MS = 5 * 60 * 1000;
+const IMAGE_FALLBACK_MODEL = "mimo-v2.5-free"; // DeepSeek 不支持图片,带图请求路由到该带图模型
 
 const userSessions = new Map();
 let cachedModels = null;
@@ -160,15 +161,20 @@ async function handleOpenAI(request) {
 	}));
 	console.log("[OAI]", new Date().toISOString(), auth.user, model, stream ? "stream" : "sync", "msgs:", JSON.stringify(msgSummary));
 
-	const transformedMessages = injectReasoningContent(model, messages);
-	const zenReq = buildZenRequest(model, transformedMessages, stream, tools, tool_choice, reasoningEffort, sessionId);
+	const upstreamModel = deepSeekNeedsImageFallback(model, messages) ? IMAGE_FALLBACK_MODEL : model;
+
+	// 纯文字请求走 DeepSeek 时,把历史里的图片剥掉(DeepSeek 无法解析 image_url)。
+	const outgoingMessages = upstreamModel === model ? stripImagesForDeepSeek(messages) : messages;
+
+	const transformedMessages = injectReasoningContent(upstreamModel, outgoingMessages);
+	const zenReq = buildZenRequest(upstreamModel, transformedMessages, stream, tools, tool_choice, reasoningEffort, sessionId);
 	logZenRequest(requestId, "openai", model, stream, auth.user, zenReq, messages?.length || 0);
 
 	let upstream;
 	try {
-		upstream = await fetchZen(zenReq, requestId, model, stream);
+		upstream = await fetchZen(zenReq, requestId, upstreamModel, stream);
 	} catch (error) {
-		debugLog("[ZEN FETCH ERROR]", { requestId, model, stream: !!stream, message: error?.message || String(error) });
+		debugLog("[ZEN FETCH ERROR]", { requestId, model: upstreamModel, stream: !!stream, message: error?.message || String(error) });
 		return upstreamErrorResponse(error);
 	}
 
@@ -297,6 +303,47 @@ function cachedModelCount() {
 const reasoningPlaceholder = " ";
 const deepSeekRegex = /deepseek/i;
 
+// DeepSeek 是否需要图片回退:仅当最近一条 user 消息带图时路由到 mimo(识别走 mimo)。
+// 历史残留的图片不影响路由:纯文字追问仍走 DeepSeek(思考走 deepseek)。
+function lastUserMessageHasImage(messages) {
+	if (!Array.isArray(messages)) return false;
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (msg?.role !== "user") continue;
+		if (!Array.isArray(msg.content)) return false;
+		return msg.content.some((part) => part?.type === "image_url" || part?.type === "image");
+	}
+	return false;
+}
+
+function deepSeekNeedsImageFallback(model, messages) {
+	return deepSeekRegex.test(model) && lastUserMessageHasImage(messages);
+}
+
+// DeepSeek 上游对整段 messages 里任何一处的 image_url 都会反序列化报错。
+// 纯文字追问会带上前一轮的图片消息,发给 DeepSeek 前把历史里的图片剥离掉。
+function stripImagesForDeepSeek(messages) {
+	if (!Array.isArray(messages)) return messages;
+	const hasImage = messages.some(
+		(msg) =>
+			Array.isArray(msg?.content) &&
+			msg.content.some((part) => part?.type === "image_url" || part?.type === "image")
+	);
+	if (!hasImage) return messages;
+
+	return messages.map((msg) => {
+		if (!Array.isArray(msg.content)) return msg;
+		const parts = msg.content.filter((part) => !(part?.type === "image_url" || part?.type === "image"));
+		if (parts.length === msg.content.length) return msg;
+
+		let content;
+		if (parts.length === 0) content = "[图片]";
+		else if (parts.every((p) => p?.type === "text")) content = parts.map((p) => p.text).join("");
+		else content = parts;
+		return { ...msg, content };
+	});
+}
+
 function injectReasoningContent(model, messages) {
 	if (!messages) return messages;
 
@@ -319,6 +366,7 @@ function injectReasoningContent(model, messages) {
 
 function buildZenRequest(model, messages, stream, tools, toolChoice, reasoningEffort, sessionId) {
 	const reqBody = { model, messages, stream: !!stream };
+	// 按实际发送的模型判断:路由到图片模型时跳过 DS 专属的 reasoning_effort
 	if (deepSeekRegex.test(model)) {
 		if (reasoningEffort !== "high" && reasoningEffort !== "max") reasoningEffort = "high";
 		reqBody.reasoning_effort = reasoningEffort;
@@ -374,7 +422,7 @@ async function openAIFullResponse(upstream, requestId, model) {
 	}
 
 	if (data?.choices) {
-		return jsonResponse(normalizeOpenAIFullData(data), upstream.status);
+		return jsonResponse(normalizeOpenAIFullData(data, model), upstream.status);
 	}
 
 	return new Response(raw, {
@@ -404,7 +452,7 @@ async function openAIStreamResponse(upstream, requestId, model) {
 
 	const encoder = new TextEncoder();
 	const decoder = new TextDecoder();
-	const normalizer = createOpenAIStreamNormalizer();
+	const normalizer = createOpenAIStreamNormalizer(model);
 
 	const stream = new ReadableStream({
 		async start(controller) {
@@ -469,8 +517,9 @@ async function openAIStreamResponse(upstream, requestId, model) {
 	});
 }
 
-function normalizeOpenAIFullData(data) {
+function normalizeOpenAIFullData(data, model) {
 	const next = { ...data };
+	if (model) next.model = model;
 	if (!Array.isArray(next.choices)) return next;
 
 	next.choices = next.choices.map((choice) => {
@@ -493,7 +542,7 @@ function normalizeOpenAIFullData(data) {
 	return next;
 }
 
-function createOpenAIStreamNormalizer() {
+function createOpenAIStreamNormalizer(model) {
 	const contentStates = new Map();
 
 	return {
@@ -503,6 +552,7 @@ function createOpenAIStreamNormalizer() {
 
 			const next = { ...chunk };
 			delete next.cost;
+			if (model) next.model = model;
 			next.choices = chunk.choices
 				.map((choice) => normalizeOpenAIStreamChoice(choice, contentStates))
 				.filter(Boolean);

--- a/server/main.go
+++ b/server/main.go
@@ -489,14 +489,9 @@ type zenRequest struct {
 
 const reasoningPlaceholder = " "
 
-func injectReasoningContent(model string, body map[string]interface{}) map[string]interface{} {
-	if body == nil || body["messages"] == nil {
-		return body
-	}
-
-	messages, ok := body["messages"].([]interface{})
-	if !ok {
-		return body
+func injectReasoningContent(model string, messages []interface{}) []interface{} {
+	if len(messages) == 0 {
+		return messages
 	}
 
 	var changed bool
@@ -518,12 +513,11 @@ func injectReasoningContent(model string, body map[string]interface{}) map[strin
 	}
 
 	if !changed {
-		return body
+		return messages
 	}
 
-	next := deepCopy(body).(map[string]interface{})
-	msgs, _ := next["messages"].([]interface{})
-	for _, msg := range msgs {
+	next := deepCopy(messages).([]interface{})
+	for _, msg := range next {
 		m, ok := msg.(map[string]interface{})
 		if !ok {
 			continue
@@ -542,6 +536,11 @@ func injectReasoningContent(model string, body map[string]interface{}) map[strin
 }
 
 var deepSeekRegex = regexp.MustCompile(`(?i)deepseek`)
+
+func partIsImage(p map[string]interface{}) bool {
+	t := getString(p["type"], "")
+	return t == "image_url" || t == "image"
+}
 
 // DeepSeek 是否需要图片回退:仅当最近一条 user 消息带图时路由到 mimo。
 // 历史残留的图片不触发,避免后续纯文字追问一直走 mimo。
@@ -563,7 +562,7 @@ func lastUserMessageHasImage(messages []interface{}) bool {
 			if !ok {
 				continue
 			}
-			if t := getString(p["type"], ""); t == "image_url" || t == "image" {
+			if partIsImage(p) {
 				return true
 			}
 		}
@@ -574,6 +573,103 @@ func lastUserMessageHasImage(messages []interface{}) bool {
 
 func deepSeekNeedsImageFallback(model string, messages []interface{}) bool {
 	return deepSeekRegex.MatchString(model) && lastUserMessageHasImage(messages)
+}
+
+// DeepSeek 上游对整段 messages 里任何一处的 image_url 都会反序列化报错。
+// 纯文字追问会带上前一轮的图片消息,发给 DeepSeek 前把历史里的图片剥离掉。
+func stripImagesForDeepSeek(messages []interface{}) []interface{} {
+	if len(messages) == 0 {
+		return messages
+	}
+
+	hasImage := false
+	for _, msg := range messages {
+		m, ok := msg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		content, ok := m["content"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, part := range content {
+			p, ok := part.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if partIsImage(p) {
+				hasImage = true
+				break
+			}
+		}
+		if hasImage {
+			break
+		}
+	}
+	if !hasImage {
+		return messages
+	}
+
+	next := make([]interface{}, len(messages))
+	for i, msg := range messages {
+		m, ok := msg.(map[string]interface{})
+		if !ok {
+			next[i] = msg
+			continue
+		}
+		content, ok := m["content"].([]interface{})
+		if !ok {
+			next[i] = m
+			continue
+		}
+
+		var parts []interface{}
+		for _, part := range content {
+			p, ok := part.(map[string]interface{})
+			if !ok {
+				parts = append(parts, part)
+				continue
+			}
+			if !partIsImage(p) {
+				parts = append(parts, p)
+			}
+		}
+		if len(parts) == len(content) {
+			next[i] = m
+			continue
+		}
+
+		copied := deepCopy(m).(map[string]interface{})
+		switch {
+		case len(parts) == 0:
+			copied["content"] = "[图片]"
+		case allTextParts(parts):
+			var b strings.Builder
+			for _, part := range parts {
+				p, _ := part.(map[string]interface{})
+				t, _ := p["text"].(string)
+				b.WriteString(t)
+			}
+			copied["content"] = b.String()
+		default:
+			copied["content"] = parts
+		}
+		next[i] = copied
+	}
+	return next
+}
+
+func allTextParts(parts []interface{}) bool {
+	for _, part := range parts {
+		p, ok := part.(map[string]interface{})
+		if !ok {
+			return false
+		}
+		if getString(p["type"], "") != "text" {
+			return false
+		}
+	}
+	return true
 }
 
 func buildZenRequest(model string, messages, tools []interface{}, toolChoice interface{}, reasoningEffort, sessionId string, stream bool) *zenRequest {
@@ -895,8 +991,12 @@ func HandleOpenAI(w http.ResponseWriter, r *http.Request, env string) {
 	if useImageModel {
 		upstreamModel = ImageFallbackModel
 	}
-	transformedBody := injectReasoningContent(upstreamModel, input.Body)
-	transformedMessages, _ := transformedBody["messages"].([]interface{})
+	// 纯文字请求走 DeepSeek 时,把历史里的图片剥掉(DeepSeek 无法解析 image_url)。
+	transformedMessages := messages
+	if upstreamModel == model {
+		transformedMessages = stripImagesForDeepSeek(messages)
+	}
+	transformedMessages = injectReasoningContent(upstreamModel, transformedMessages)
 
 	msgSummary := formatMsgSummary(transformedMessages)
 	log.Println("[OAI]", time.Now().UTC().Format(time.RFC3339), user, model,

--- a/server/main.go
+++ b/server/main.go
@@ -23,19 +23,20 @@ import (
 )
 
 const (
-	ProxyVersion   = "v1.3.0"
-	OCVersion      = "1.15.13"
-	ZenBaseURL     = "https://opencode.ai"
-	ZenURL         = ZenBaseURL + "/zen/v1/chat/completions"
-	ZenModelsURL   = ZenBaseURL + "/zen/v1/models"
-	defaultTimeout = 5 * time.Minute
+	ProxyVersion       = "v1.3.0"
+	OCVersion          = "1.15.13"
+	ZenBaseURL         = "https://opencode.ai"
+	ZenURL             = ZenBaseURL + "/zen/v1/chat/completions"
+	ZenModelsURL       = ZenBaseURL + "/zen/v1/models"
+	defaultTimeout     = 5 * time.Minute
+	ImageFallbackModel = "mimo-v2.5-free" // DeepSeek 不支持图片,带图请求路由到该带图模型
 )
 
 type Config struct {
-	Port        int    `yaml:"port"`
-	APIKey      string `yaml:"api-key"`
-	Debug       bool   `yaml:"debug"`
-	TimeoutMs   int    `yaml:"timeout-ms"`
+	Port      int    `yaml:"port"`
+	APIKey    string `yaml:"api-key"`
+	Debug     bool   `yaml:"debug"`
+	TimeoutMs int    `yaml:"timeout-ms"`
 }
 
 var (
@@ -542,12 +543,46 @@ func injectReasoningContent(model string, body map[string]interface{}) map[strin
 
 var deepSeekRegex = regexp.MustCompile(`(?i)deepseek`)
 
+// DeepSeek 是否需要图片回退:仅当最近一条 user 消息带图时路由到 mimo。
+// 历史残留的图片不触发,避免后续纯文字追问一直走 mimo。
+func lastUserMessageHasImage(messages []interface{}) bool {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m, ok := messages[i].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if getString(m["role"], "") != "user" {
+			continue
+		}
+		content, ok := m["content"].([]interface{})
+		if !ok {
+			return false
+		}
+		for _, part := range content {
+			p, ok := part.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if t := getString(p["type"], ""); t == "image_url" || t == "image" {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+func deepSeekNeedsImageFallback(model string, messages []interface{}) bool {
+	return deepSeekRegex.MatchString(model) && lastUserMessageHasImage(messages)
+}
+
 func buildZenRequest(model string, messages, tools []interface{}, toolChoice interface{}, reasoningEffort, sessionId string, stream bool) *zenRequest {
 	body := map[string]interface{}{
 		"model":    model,
 		"messages": messages,
 		"stream":   stream,
 	}
+	// 按实际发送的模型判断:路由到图片模型时跳过 DS 专属的 reasoning_effort
 	if deepSeekRegex.MatchString(model) {
 		if reasoningEffort != "high" && reasoningEffort != "max" {
 			reasoningEffort = "high"
@@ -595,7 +630,7 @@ func fetchZen(ctx context.Context, zenReq *zenRequest) (*http.Response, error) {
 		client = newZenHTTPClient()
 	}
 	return client.Do(req)
-	}
+}
 
 func parseZenError(raw string) *zenError {
 	text := strings.TrimSpace(raw)
@@ -693,8 +728,11 @@ func logUpstreamBody(env, requestId, model string, status int, raw string, zenEr
 	log.Println("[ZEN BODY]", marshalJSON(payload))
 }
 
-func normalizeOpenAIFullData(data map[string]interface{}) map[string]interface{} {
+func normalizeOpenAIFullData(data map[string]interface{}, model string) map[string]interface{} {
 	next := deepCopy(data).(map[string]interface{})
+	if model != "" {
+		next["model"] = model
+	}
 	choices, ok := next["choices"].([]interface{})
 	if !ok {
 		return next
@@ -737,10 +775,11 @@ func normalizeOpenAIFullData(data map[string]interface{}) map[string]interface{}
 
 type streamNormalizer struct {
 	contentStates map[int]*thinkState
+	model         string
 }
 
-func newStreamNormalizer() *streamNormalizer {
-	return &streamNormalizer{contentStates: make(map[int]*thinkState)}
+func newStreamNormalizer(model string) *streamNormalizer {
+	return &streamNormalizer{contentStates: make(map[int]*thinkState), model: model}
 }
 
 func (n *streamNormalizer) normalize(chunk map[string]interface{}) map[string]interface{} {
@@ -759,6 +798,9 @@ func (n *streamNormalizer) normalize(chunk map[string]interface{}) map[string]in
 
 	next := deepCopy(chunk).(map[string]interface{})
 	delete(next, "cost")
+	if n.model != "" {
+		next["model"] = n.model
+	}
 
 	var newChoices []interface{}
 	for _, c := range choices {
@@ -848,20 +890,25 @@ func HandleOpenAI(w http.ResponseWriter, r *http.Request, env string) {
 
 	sessionId := getSession(user)
 
-	transformedBody := injectReasoningContent(model, input.Body)
+	useImageModel := deepSeekNeedsImageFallback(model, messages)
+	upstreamModel := model
+	if useImageModel {
+		upstreamModel = ImageFallbackModel
+	}
+	transformedBody := injectReasoningContent(upstreamModel, input.Body)
 	transformedMessages, _ := transformedBody["messages"].([]interface{})
 
 	msgSummary := formatMsgSummary(transformedMessages)
 	log.Println("[OAI]", time.Now().UTC().Format(time.RFC3339), user, model,
 		map[bool]string{true: "stream", false: "sync"}[stream], "msgs:", msgSummary)
 
-	zenReq := buildZenRequest(model, transformedMessages, tools, toolChoice, reasoningEffort, sessionId, stream)
+	zenReq := buildZenRequest(upstreamModel, transformedMessages, tools, toolChoice, reasoningEffort, sessionId, stream)
 	logZenRequest(requestId, "openai", model, stream, user, zenReq, len(messages))
 
 	upstream, err := fetchZen(r.Context(), zenReq)
 	if err != nil {
 		debugLog("[ZEN FETCH ERROR]", map[string]interface{}{
-			"requestId": requestId, "model": model, "stream": stream,
+			"requestId": requestId, "model": upstreamModel, "stream": stream,
 			"message": err.Error(),
 		})
 		writeUpstreamError(w, err)
@@ -870,7 +917,7 @@ func HandleOpenAI(w http.ResponseWriter, r *http.Request, env string) {
 	defer upstream.Body.Close()
 
 	logZenResponse(env, map[string]interface{}{
-		"requestId": requestId, "model": model, "stream": stream,
+		"requestId": requestId, "model": upstreamModel, "stream": stream,
 		"status": upstream.StatusCode, "ok": upstream.StatusCode < 400,
 		"ms": 0,
 	})
@@ -904,7 +951,7 @@ func OpenAIFullResponse(w http.ResponseWriter, upstream *http.Response, requestI
 	}
 
 	if data != nil && data["choices"] != nil {
-		JSONResponse(w, normalizeOpenAIFullData(data), upstream.StatusCode)
+		JSONResponse(w, normalizeOpenAIFullData(data, model), upstream.StatusCode)
 		return
 	}
 
@@ -954,7 +1001,7 @@ func OpenAIStreamResponse(w http.ResponseWriter, r *http.Request, upstream *http
 		return
 	}
 
-	normalizer := newStreamNormalizer()
+	normalizer := newStreamNormalizer(model)
 	doneSent := false
 
 	sendSSE := func(data interface{}) {
@@ -1062,8 +1109,9 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 		HandleOpenAI(w, r, "")
 	default:
 		JSONResponse(w, map[string]interface{}{"error": map[string]interface{}{"message": "Not found"}}, http.StatusNotFound)
+	}
 }
-}
+
 var ipv4Regex = regexp.MustCompile(`\b\d{1,3}(?:\.\d{1,3}){3}\b`)
 
 var ipProviders = []string{


### PR DESCRIPTION
- DeepSeek 仅支持文本:最近一条 user 消息带图时路由到 mimo-v2.5-free,响应 model 字段改写回请求的模型
- 纯文字追问仍走 DeepSeek(思考),发送前剥离历史中的图片,避免上游反序列化报错
- server/main.go 同步图片回退与 model 改写逻辑
- README 补充图片请求说明